### PR TITLE
new options in synth dataset

### DIFF
--- a/causaltune/datasets.py
+++ b/causaltune/datasets.py
@@ -544,7 +544,7 @@ def generate_non_random_dataset(num_samples=1000):
     return cd
 
 
-def synth_variance_reduction_experiment(
+def mlrate_experiment_synth_dgp(
     n_samples=10000, n_x=100, const_te=0, noise=1, cate_scaler=1
 ):
     """Synthetic DGP taken from

--- a/causaltune/models/dummy.py
+++ b/causaltune/models/dummy.py
@@ -56,7 +56,7 @@ class DummyModel(DoWhyMethods):
 
     def predict(self, X: pd.DataFrame) -> np.ndarray:
         mean_, _, _ = Scorer.naive_ate(X[self.treatment_name], X[self.outcome_name])
-        return np.ones(len(X)) * mean_ * (1 + 0.01 * np.random.normal(size=(len(X),)))
+        return np.ones(len(X)) * mean_ * (1 + 10e-5 * np.random.normal(size=(len(X),)))
 
 
 class PropensityScoreWeighter(DoWhyMethods):
@@ -129,7 +129,7 @@ class Dummy(MultivaluePSW):
 
     def effect(self, df: pd.DataFrame, **kwargs):
         effect = super(MultivaluePSW, self).effect(df, **kwargs)
-        return effect * (1 + 0.01 * np.random.normal(size=effect.shape))
+        return effect * (1 + 10e-5 * np.random.normal(size=effect.shape))
 
 
 class NaiveDummy(DoWhyWrapper):


### PR DESCRIPTION
## Problem

- add more options to variance reduction experiment data
- reducing perturbation in effect calculation


## Proposed changes

_Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request.
If it fixes a bug or resolves a feature request, be sure to link to that issue._


## Types of changes

What types of changes does your code introduce to causaltune?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] I have read the [CONTRIBUTING](../CONTRIBUTING.md) doc
- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Unit tests for changes (not needed for documentation changes)
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions
